### PR TITLE
fix. wrong datatype in munin_docs.

### DIFF
--- a/mongo_docs
+++ b/mongo_docs
@@ -32,7 +32,7 @@ def doConfig():
     for k in getServerStatus()["metrics"]["document"]:
         print k + ".label " + k
         print k + ".min 0"
-        print k + ".type COUNTER"
+        print k + ".type GAUGE"
         print k + ".max 500000"
         print k + ".draw LINE1"
 

--- a/src/body_docs.py
+++ b/src/body_docs.py
@@ -17,7 +17,7 @@ def doConfig():
     for k in getServerStatus()["metrics"]["document"]:
         print k + ".label " + k
         print k + ".min 0"
-        print k + ".type COUNTER"
+        print k + ".type GAUGE"
         print k + ".max 500000"
         print k + ".draw LINE1"
 


### PR DESCRIPTION
Munin-run returns absolute values, like total documents inserted, deleted, etc. And on graphic it was drawing like documents per munite. We have mongo_ops for that, so i believe that original idea for mongo_docs plugin was about total numbers.
